### PR TITLE
test

### DIFF
--- a/x-pack/plugins/security/server/routes/analytics/authentication_type.ts
+++ b/x-pack/plugins/security/server/routes/analytics/authentication_type.ts
@@ -31,6 +31,12 @@ export function defineRecordAnalyticsOnAuthTypeRoutes({
   router.post(
     {
       path: '/internal/security/analytics/_record_auth_type',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route is opted out from authorization',
+        },
+      },
       validate: {
         body: schema.nullable(
           schema.object({ signature: schema.string(), timestamp: schema.number() })

--- a/x-pack/plugins/security/server/routes/analytics/record_violations.ts
+++ b/x-pack/plugins/security/server/routes/analytics/record_violations.ts
@@ -135,6 +135,12 @@ export function defineRecordViolations({ router, analyticsService }: RouteDefini
   router.post(
     {
       path: '/internal/security/analytics/_record_violations',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route is opted out from authorization',
+        },
+      },
       validate: {
         /**
          * Chrome supports CSP3 spec and sends an array of reports. Safari only sends a single

--- a/x-pack/plugins/security/server/routes/anonymous_access/get_capabilities.ts
+++ b/x-pack/plugins/security/server/routes/anonymous_access/get_capabilities.ts
@@ -15,7 +15,16 @@ export function defineAnonymousAccessGetCapabilitiesRoutes({
   getAnonymousAccessService,
 }: RouteDefinitionParams) {
   router.get(
-    { path: '/internal/security/anonymous_access/capabilities', validate: false },
+    {
+      path: '/internal/security/anonymous_access/capabilities',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route is opted out from authorization',
+        },
+      },
+      validate: false,
+    },
     async (_context, request, response) => {
       const anonymousAccessService = getAnonymousAccessService();
       return response.ok({ body: await anonymousAccessService.getCapabilities(request) });

--- a/x-pack/plugins/security/server/routes/anonymous_access/get_state.ts
+++ b/x-pack/plugins/security/server/routes/anonymous_access/get_state.ts
@@ -18,7 +18,16 @@ export function defineAnonymousAccessGetStateRoutes({
   getAnonymousAccessService,
 }: RouteDefinitionParams) {
   router.get(
-    { path: '/internal/security/anonymous_access/state', validate: false },
+    {
+      path: '/internal/security/anonymous_access/state',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route is opted out from authorization',
+        },
+      },
+      validate: false,
+    },
     async (_context, _request, response) => {
       const anonymousAccessService = getAnonymousAccessService();
       const accessURLParameters = anonymousAccessService.accessURLParameters

--- a/x-pack/plugins/security/server/routes/api_keys/create.ts
+++ b/x-pack/plugins/security/server/routes/api_keys/create.ts
@@ -32,6 +32,12 @@ export function defineCreateApiKeyRoutes({
   router.post(
     {
       path: '/internal/security/api_key',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route is opted out from authorization',
+        },
+      },
       validate: {
         body: schema.oneOf([
           restApiKeySchema,

--- a/x-pack/plugins/security/server/routes/api_keys/enabled.ts
+++ b/x-pack/plugins/security/server/routes/api_keys/enabled.ts
@@ -16,6 +16,12 @@ export function defineEnabledApiKeysRoutes({
   router.get(
     {
       path: '/internal/security/api_key/_enabled',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route is opted out from authorization',
+        },
+      },
       validate: false,
     },
     createLicensedRouteHandler(async (context, request, response) => {

--- a/x-pack/plugins/security/server/routes/api_keys/has_active.ts
+++ b/x-pack/plugins/security/server/routes/api_keys/has_active.ts
@@ -22,6 +22,12 @@ export function defineHasApiKeysRoutes({
   router.get(
     {
       path: '/internal/security/api_key/_has_active',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route is opted out from authorization',
+        },
+      },
       validate: false,
       options: {
         access: 'internal',

--- a/x-pack/plugins/security/server/routes/api_keys/invalidate.ts
+++ b/x-pack/plugins/security/server/routes/api_keys/invalidate.ts
@@ -21,6 +21,12 @@ export function defineInvalidateApiKeysRoutes({ router }: RouteDefinitionParams)
   router.post(
     {
       path: '/internal/security/api_key/invalidate',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route is opted out from authorization',
+        },
+      },
       validate: {
         body: schema.object({
           apiKeys: schema.arrayOf(schema.object({ id: schema.string(), name: schema.string() })),

--- a/x-pack/plugins/security/server/routes/api_keys/query.ts
+++ b/x-pack/plugins/security/server/routes/api_keys/query.ts
@@ -25,6 +25,12 @@ export function defineQueryApiKeysAndAggregationsRoute({
     // on behalf of the user making the request and governed by the user's own cluster privileges.
     {
       path: '/internal/security/api_key/_query',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route is opted out from authorization',
+        },
+      },
       validate: {
         body: schema.object({
           query: schema.maybe(schema.object({}, { unknowns: 'allow' })),

--- a/x-pack/plugins/security/server/routes/api_keys/update.ts
+++ b/x-pack/plugins/security/server/routes/api_keys/update.ts
@@ -34,6 +34,12 @@ export function defineUpdateApiKeyRoutes({
   router.put(
     {
       path: '/internal/security/api_key',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route is opted out from authorization',
+        },
+      },
       validate: {
         body: schema.oneOf([
           updateRestApiKeySchema,

--- a/x-pack/plugins/security/server/routes/authentication/common.ts
+++ b/x-pack/plugins/security/server/routes/authentication/common.ts
@@ -43,6 +43,12 @@ export function defineCommonRoutes({
     router.get(
       {
         path,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         // Allow unknown query parameters as this endpoint can be hit by the 3rd-party with any
         // set of query string parameters (e.g. SAML/OIDC logout request/response parameters).
         validate: { query: schema.object({}, { unknowns: 'allow' }) },
@@ -90,7 +96,16 @@ export function defineCommonRoutes({
     ...(buildFlavor !== 'serverless' ? ['/api/security/v1/me'] : []),
   ]) {
     router.get(
-      { path, validate: false },
+      {
+        path,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
+        validate: false,
+      },
       createLicensedRouteHandler(async (context, request, response) => {
         if (path === '/api/security/v1/me') {
           logger.warn(
@@ -137,6 +152,12 @@ export function defineCommonRoutes({
   router.post(
     {
       path: '/internal/security/login',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route is opted out from authorization',
+        },
+      },
       validate: {
         body: schema.object({
           providerType: schema.string(),
@@ -181,7 +202,16 @@ export function defineCommonRoutes({
   if (buildFlavor !== 'serverless') {
     // In the serverless offering, the access agreement functionality isn't available.
     router.post(
-      { path: '/internal/security/access_agreement/acknowledge', validate: false },
+      {
+        path: '/internal/security/access_agreement/acknowledge',
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
+        validate: false,
+      },
       createLicensedRouteHandler(async (context, request, response) => {
         // If license doesn't allow access agreement we shouldn't handle request.
         if (!license.getFeatures().allowAccessAgreement) {

--- a/x-pack/plugins/security/server/routes/authentication/oidc.ts
+++ b/x-pack/plugins/security/server/routes/authentication/oidc.ts
@@ -87,6 +87,12 @@ export function defineOIDCRoutes({
     router.get(
       {
         path,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: {
           query: schema.object(
             {
@@ -171,6 +177,12 @@ export function defineOIDCRoutes({
     router.post(
       {
         path,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: {
           body: schema.object(
             {
@@ -214,6 +226,12 @@ export function defineOIDCRoutes({
   router.get(
     {
       path: '/api/security/oidc/initiate_login',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route is opted out from authorization',
+        },
+      },
       validate: {
         query: schema.object(
           {

--- a/x-pack/plugins/security/server/routes/authentication/saml.ts
+++ b/x-pack/plugins/security/server/routes/authentication/saml.ts
@@ -30,6 +30,12 @@ export function defineSAMLRoutes({
     router.post(
       {
         path,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: {
           body: schema.object(
             { SAMLResponse: schema.string(), RelayState: schema.maybe(schema.string()) },

--- a/x-pack/plugins/security/server/routes/authorization/privileges/get.ts
+++ b/x-pack/plugins/security/server/routes/authorization/privileges/get.ts
@@ -14,6 +14,12 @@ export function defineGetPrivilegesRoutes({ router, authz }: RouteDefinitionPara
   router.get(
     {
       path: '/api/security/privileges',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route is opted out from authorization',
+        },
+      },
       validate: {
         query: schema.object({
           // We don't use `schema.boolean` here, because all query string parameters are treated as

--- a/x-pack/plugins/security/server/routes/authorization/privileges/get_builtin.ts
+++ b/x-pack/plugins/security/server/routes/authorization/privileges/get_builtin.ts
@@ -9,7 +9,16 @@ import type { RouteDefinitionParams } from '../..';
 
 export function defineGetBuiltinPrivilegesRoutes({ router }: RouteDefinitionParams) {
   router.get(
-    { path: '/internal/security/esPrivileges/builtin', validate: false },
+    {
+      path: '/internal/security/esPrivileges/builtin',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route is opted out from authorization',
+        },
+      },
+      validate: false,
+    },
     async (context, request, response) => {
       const esClient = (await context.core).elasticsearch.client;
       const privileges = await esClient.asCurrentUser.security.getBuiltinPrivileges();

--- a/x-pack/plugins/security/server/routes/authorization/roles/get_all_by_space.ts
+++ b/x-pack/plugins/security/server/routes/authorization/roles/get_all_by_space.ts
@@ -24,8 +24,10 @@ export function defineGetAllRolesBySpaceRoutes({
   router.get(
     {
       path: '/internal/security/roles/{spaceId}',
-      options: {
-        tags: ['access:manageSpaces'],
+      security: {
+        authz: {
+          requiredPrivileges: ['manageSpaces'],
+        },
       },
       validate: {
         params: schema.object({ spaceId: schema.string({ minLength: 1 }) }),

--- a/x-pack/plugins/security/server/routes/authorization/spaces/share_saved_object_permissions.ts
+++ b/x-pack/plugins/security/server/routes/authorization/spaces/share_saved_object_permissions.ts
@@ -19,6 +19,12 @@ export function defineShareSavedObjectPermissionRoutes({
   router.get(
     {
       path: '/internal/security/_share_saved_object_permissions',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route is opted out from authorization',
+        },
+      },
       validate: { query: schema.object({ type: schema.string() }) },
     },
     createLicensedRouteHandler(async (context, request, response) => {

--- a/x-pack/plugins/security/server/routes/deprecations/kibana_user_role.ts
+++ b/x-pack/plugins/security/server/routes/deprecations/kibana_user_role.ts
@@ -23,6 +23,12 @@ export function defineKibanaUserRoleDeprecationRoutes({ router, logger }: RouteD
   router.post(
     {
       path: '/internal/security/deprecations/kibana_user_role/_fix_users',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route is opted out from authorization',
+        },
+      },
       validate: false,
     },
     createLicensedRouteHandler(async (context, request, response) => {
@@ -88,6 +94,12 @@ export function defineKibanaUserRoleDeprecationRoutes({ router, logger }: RouteD
   router.post(
     {
       path: '/internal/security/deprecations/kibana_user_role/_fix_role_mappings',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route is opted out from authorization',
+        },
+      },
       validate: false,
     },
     createLicensedRouteHandler(async (context, request, response) => {

--- a/x-pack/plugins/security/server/routes/feature_check/feature_check.ts
+++ b/x-pack/plugins/security/server/routes/feature_check/feature_check.ts
@@ -43,6 +43,12 @@ export function defineSecurityFeatureCheckRoute({ router, logger }: RouteDefinit
   router.get(
     {
       path: '/internal/security/_check_security_features',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route is opted out from authorization',
+        },
+      },
       validate: false,
     },
     createLicensedRouteHandler(async (context, request, response) => {

--- a/x-pack/plugins/security/server/routes/indices/get_fields.ts
+++ b/x-pack/plugins/security/server/routes/indices/get_fields.ts
@@ -14,6 +14,12 @@ export function defineGetFieldsRoutes({ router }: RouteDefinitionParams) {
   router.get(
     {
       path: '/internal/security/fields/{query}',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route is opted out from authorization',
+        },
+      },
       validate: { params: schema.object({ query: schema.string() }) },
     },
     async (context, request, response) => {

--- a/x-pack/plugins/security/server/routes/role_mapping/delete.ts
+++ b/x-pack/plugins/security/server/routes/role_mapping/delete.ts
@@ -15,6 +15,12 @@ export function defineRoleMappingDeleteRoutes({ router }: RouteDefinitionParams)
   router.delete(
     {
       path: '/internal/security/role_mapping/{name}',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route is opted out from authorization',
+        },
+      },
       validate: {
         params: schema.object({
           name: schema.string(),

--- a/x-pack/plugins/security/server/routes/role_mapping/get.ts
+++ b/x-pack/plugins/security/server/routes/role_mapping/get.ts
@@ -18,6 +18,12 @@ export function defineRoleMappingGetRoutes(params: RouteDefinitionParams) {
   router.get(
     {
       path: '/internal/security/role_mapping/{name?}',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route is opted out from authorization',
+        },
+      },
       validate: {
         params: schema.object({
           name: schema.maybe(schema.string()),

--- a/x-pack/plugins/security/server/routes/role_mapping/post.ts
+++ b/x-pack/plugins/security/server/routes/role_mapping/post.ts
@@ -15,6 +15,12 @@ export function defineRoleMappingPostRoutes({ router }: RouteDefinitionParams) {
   router.post(
     {
       path: '/internal/security/role_mapping/{name}',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route is opted out from authorization',
+        },
+      },
       validate: {
         params: schema.object({
           name: schema.string(),

--- a/x-pack/plugins/security/server/routes/security_checkup/get_state.ts
+++ b/x-pack/plugins/security/server/routes/security_checkup/get_state.ts
@@ -29,7 +29,16 @@ export function defineSecurityCheckupGetStateRoutes({
   const doesClusterHaveUserData = createClusterDataCheck();
 
   router.get(
-    { path: '/internal/security/security_checkup/state', validate: false },
+    {
+      path: '/internal/security/security_checkup/state',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route is opted out from authorization',
+        },
+      },
+      validate: false,
+    },
     async (context, _request, response) => {
       const esClient = (await context.core).elasticsearch.client;
       let displayAlert = false;

--- a/x-pack/plugins/security/server/routes/session_management/extend.ts
+++ b/x-pack/plugins/security/server/routes/session_management/extend.ts
@@ -14,6 +14,12 @@ export function defineSessionExtendRoutes({ router, basePath }: RouteDefinitionP
   router.post(
     {
       path: '/internal/security/session',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route is opted out from authorization',
+        },
+      },
       validate: false,
     },
     async (_context, _request, response) => {

--- a/x-pack/plugins/security/server/routes/session_management/info.ts
+++ b/x-pack/plugins/security/server/routes/session_management/info.ts
@@ -14,7 +14,16 @@ import type { SessionInfo } from '../../../common/types';
  */
 export function defineSessionInfoRoutes({ router, getSession }: RouteDefinitionParams) {
   router.get(
-    { path: '/internal/security/session', validate: false },
+    {
+      path: '/internal/security/session',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route is opted out from authorization',
+        },
+      },
+      validate: false,
+    },
     async (_context, request, response) => {
       const { value: sessionValue } = await getSession().get(request);
       if (sessionValue) {

--- a/x-pack/plugins/security/server/routes/session_management/invalidate.ts
+++ b/x-pack/plugins/security/server/routes/session_management/invalidate.ts
@@ -33,9 +33,14 @@ export function defineInvalidateSessionsRoutes({ router, getSession }: RouteDefi
           ),
         }),
       },
+      security: {
+        authz: {
+          requiredPrivileges: ['sessionManagement'],
+        },
+      },
       options: {
         access: 'public',
-        tags: ['access:sessionManagement'],
+
         summary: `Invalidate user sessions`,
       },
     },

--- a/x-pack/plugins/security/server/routes/user_profile/bulk_get.ts
+++ b/x-pack/plugins/security/server/routes/user_profile/bulk_get.ts
@@ -24,7 +24,11 @@ export function defineBulkGetUserProfilesRoute({
           dataPath: schema.maybe(schema.string()),
         }),
       },
-      options: { tags: ['access:bulkGetUserProfiles'] },
+      security: {
+        authz: {
+          requiredPrivileges: ['bulkGetUserProfiles'],
+        },
+      },
     },
     createLicensedRouteHandler(async (context, request, response) => {
       const userProfileServiceInternal = getUserProfileService();

--- a/x-pack/plugins/security/server/routes/user_profile/get_current.ts
+++ b/x-pack/plugins/security/server/routes/user_profile/get_current.ts
@@ -20,6 +20,12 @@ export function defineGetCurrentUserProfileRoute({
   router.get(
     {
       path: '/internal/security/user_profile',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route is opted out from authorization',
+        },
+      },
       validate: {
         query: schema.object({ dataPath: schema.maybe(schema.string()) }),
       },

--- a/x-pack/plugins/security/server/routes/user_profile/update.ts
+++ b/x-pack/plugins/security/server/routes/user_profile/update.ts
@@ -27,6 +27,12 @@ export function defineUpdateUserProfileDataRoute({
   router.post(
     {
       path: '/internal/security/user_profile/_data',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route is opted out from authorization',
+        },
+      },
       validate: {
         body: schema.recordOf(schema.string(), schema.any()),
       },

--- a/x-pack/plugins/security/server/routes/users/change_password.ts
+++ b/x-pack/plugins/security/server/routes/users/change_password.ts
@@ -24,6 +24,12 @@ export function defineChangeUserPasswordRoutes({
   router.post(
     {
       path: '/internal/security/users/{username}/password',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route is opted out from authorization',
+        },
+      },
       validate: {
         params: schema.object({ username: schema.string({ minLength: 1, maxLength: 1024 }) }),
         body: schema.object({

--- a/x-pack/plugins/security/server/routes/users/create_or_update.ts
+++ b/x-pack/plugins/security/server/routes/users/create_or_update.ts
@@ -15,6 +15,12 @@ export function defineCreateOrUpdateUserRoutes({ router }: RouteDefinitionParams
   router.post(
     {
       path: '/internal/security/users/{username}',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route is opted out from authorization',
+        },
+      },
       validate: {
         params: schema.object({ username: schema.string({ minLength: 1, maxLength: 1024 }) }),
         body: schema.object({

--- a/x-pack/plugins/security/server/routes/users/delete.ts
+++ b/x-pack/plugins/security/server/routes/users/delete.ts
@@ -15,6 +15,12 @@ export function defineDeleteUserRoutes({ router }: RouteDefinitionParams) {
   router.delete(
     {
       path: '/internal/security/users/{username}',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route is opted out from authorization',
+        },
+      },
       validate: {
         params: schema.object({ username: schema.string({ minLength: 1, maxLength: 1024 }) }),
       },

--- a/x-pack/plugins/security/server/routes/users/disable.ts
+++ b/x-pack/plugins/security/server/routes/users/disable.ts
@@ -15,6 +15,12 @@ export function defineDisableUserRoutes({ router }: RouteDefinitionParams) {
   router.post(
     {
       path: '/internal/security/users/{username}/_disable',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route is opted out from authorization',
+        },
+      },
       validate: {
         params: schema.object({ username: schema.string({ minLength: 1, maxLength: 1024 }) }),
       },

--- a/x-pack/plugins/security/server/routes/users/enable.ts
+++ b/x-pack/plugins/security/server/routes/users/enable.ts
@@ -15,6 +15,12 @@ export function defineEnableUserRoutes({ router }: RouteDefinitionParams) {
   router.post(
     {
       path: '/internal/security/users/{username}/_enable',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route is opted out from authorization',
+        },
+      },
       validate: {
         params: schema.object({ username: schema.string({ minLength: 1, maxLength: 1024 }) }),
       },

--- a/x-pack/plugins/security/server/routes/users/get.ts
+++ b/x-pack/plugins/security/server/routes/users/get.ts
@@ -15,6 +15,12 @@ export function defineGetUserRoutes({ router }: RouteDefinitionParams) {
   router.get(
     {
       path: '/internal/security/users/{username}',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route is opted out from authorization',
+        },
+      },
       validate: {
         params: schema.object({ username: schema.string({ minLength: 1, maxLength: 1024 }) }),
       },

--- a/x-pack/plugins/security/server/routes/users/get_all.ts
+++ b/x-pack/plugins/security/server/routes/users/get_all.ts
@@ -11,7 +11,16 @@ import { createLicensedRouteHandler } from '../licensed_route_handler';
 
 export function defineGetAllUsersRoutes({ router }: RouteDefinitionParams) {
   router.get(
-    { path: '/internal/security/users', validate: false },
+    {
+      path: '/internal/security/users',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route is opted out from authorization',
+        },
+      },
+      validate: false,
+    },
     createLicensedRouteHandler(async (context, request, response) => {
       try {
         const esClient = (await context.core).elasticsearch.client;

--- a/x-pack/plugins/security/server/routes/views/access_agreement.ts
+++ b/x-pack/plugins/security/server/routes/views/access_agreement.ts
@@ -35,7 +35,16 @@ export function defineAccessAgreementRoutes({
   );
 
   router.get(
-    { path: '/internal/security/access_agreement/state', validate: false },
+    {
+      path: '/internal/security/access_agreement/state',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route is opted out from authorization',
+        },
+      },
+      validate: false,
+    },
     createLicensedRouteHandler(async (context, request, response) => {
       if (!canHandleRequest()) {
         return response.forbidden({

--- a/x-pack/plugins/security/server/routes/views/login.ts
+++ b/x-pack/plugins/security/server/routes/views/login.ts
@@ -57,7 +57,17 @@ export function defineLoginRoutes({
   );
 
   router.get(
-    { path: '/internal/security/login_state', validate: false, options: { authRequired: false } },
+    {
+      path: '/internal/security/login_state',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route is opted out from authorization',
+        },
+      },
+      validate: false,
+      options: { authRequired: false },
+    },
     async (context, request, response) => {
       const { allowLogin, layout = 'form' } = license.getFeatures();
       const { sortedProviders, selector } = config.authc;


### PR DESCRIPTION

### ESLint Fixes for Access Tag Migration

This PR migrates `access:<privilege>` tags used in route definitions.

### **Before Migration:**
Access control tags were defined in the `options` object of the route, using the `access:<privilege>` pattern:

```ts
router.get({
  path: '/api/path',
  options: {
    tags: ['access:<privilege_1>', 'access:<privilege_2>'],
  },
  ...
}, handler);
```

### **After Migration:**
After the migration, these tags have been replaced with the more robust `security.authz.requiredPrivileges` field under `security`:

```ts
router.get({
  path: '/api/path',
  security: {
    authz: {
      requiredPrivileges: ['<privilege_1>', '<privilege_2>'],
    },
  },
  ...
}, handler);
```
