### PR TITLE
Authorized Route Migration for routes owned by @elastic/kibana-security

### DIFF
--- a/x-pack/plugins/security/server/routes/authorization/roles/get_all_by_space.ts
+++ b/x-pack/plugins/security/server/routes/authorization/roles/get_all_by_space.ts
@@ -24,8 +24,10 @@ export function defineGetAllRolesBySpaceRoutes({
   router.get(
     {
       path: '/internal/security/roles/{spaceId}',
-      options: {
-        tags: ['access:manageSpaces'],
+      security: {
+        authz: {
+          requiredPrivileges: ['manageSpaces'],
+        },
       },
       validate: {
         params: schema.object({ spaceId: schema.string({ minLength: 1 }) }),

--- a/x-pack/plugins/security/server/routes/session_management/invalidate.ts
+++ b/x-pack/plugins/security/server/routes/session_management/invalidate.ts
@@ -33,9 +33,14 @@ export function defineInvalidateSessionsRoutes({ router, getSession }: RouteDefi
           ),
         }),
       },
+      security: {
+        authz: {
+          requiredPrivileges: ['sessionManagement'],
+        },
+      },
       options: {
         access: 'public',
-        tags: ['access:sessionManagement'],
+
         summary: `Invalidate user sessions`,
       },
     },

--- a/x-pack/plugins/security/server/routes/user_profile/bulk_get.ts
+++ b/x-pack/plugins/security/server/routes/user_profile/bulk_get.ts
@@ -24,7 +24,11 @@ export function defineBulkGetUserProfilesRoute({
           dataPath: schema.maybe(schema.string()),
         }),
       },
-      options: { tags: ['access:bulkGetUserProfiles'] },
+      security: {
+        authz: {
+          requiredPrivileges: ['bulkGetUserProfiles'],
+        },
+      },
     },
     createLicensedRouteHandler(async (context, request, response) => {
       const userProfileServiceInternal = getUserProfileService();


### PR DESCRIPTION
### Authz API migration for authorized routes

This PR migrates `access:<privilege>` tags used in route definitions to new security configuration.
Please refer to the documentation for more information: [Authorization API](https://docs.elastic.dev/kibana-dev-docs/key-concepts/security-api-authorization)

### **Before Migration:**
Access control tags were defined in the `options` object of the route:

```ts
router.get({
  path: '/api/path',
  options: {
    tags: ['access:<privilege_1>', 'access:<privilege_2>'],
  },
  ...
}, handler);
```

### **After Migration:**
Tags have been replaced with the more robust `security.authz.requiredPrivileges` field under `security`:

```ts
router.get({
  path: '/api/path',
  security: {
    authz: {
      requiredPrivileges: ['<privilege_1>', '<privilege_2>'],
    },
  },
  ...
}, handler);
```

### What to do next?
1. Review the changes in this PR.
2. You might need to update your tests to reflect the new security configuration:
    - If you have tests that rely on checking `access` tags.
    - If you have snapshot tests that include the route definition.
    - If you have FTR tests that rely on checking unauthorized error message.  The error message changed to also include missing privileges.

## Any questions?
If you have any questions or need help with API authorization, please reach out to the `@elastic/kibana-security` team.
